### PR TITLE
Add multi-platform CMake workflow configuration

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,0 +1,75 @@
+# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
+name: CMake on multiple platforms
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      # Set up a matrix to run the following 3 configurations:
+      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
+      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
+      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      #
+      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        build_type: [Release]
+        c_compiler: [gcc, clang, cl]
+        include:
+          - os: windows-latest
+            c_compiler: cl
+            cpp_compiler: cl
+          - os: ubuntu-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+        exclude:
+          - os: windows-latest
+            c_compiler: gcc
+          - os: windows-latest
+            c_compiler: clang
+          - os: ubuntu-latest
+            c_compiler: cl
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set reusable strings
+      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -S ${{ github.workspace }}
+
+    - name: Build
+      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+    - name: Test
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
+      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest --build-config ${{ matrix.build_type }}

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -91,4 +91,4 @@ jobs:
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --build-config ${{ matrix.build_type }}
+      run: ctest --build-config ${{ matrix.build_type }} --output-on-failure

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,5 +1,3 @@
-# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
-# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
 name: CMake on multiple platforms
 
 on:
@@ -47,6 +45,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install -y libsdl2-dev libglew-dev
+
+    - name: Install dependencies (Windows)
+      if: runner.os == 'Windows'
+      run: vcpkg install sdl2:x64-windows-static glew:x64-windows-static
+
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
       id: strings
@@ -54,7 +60,8 @@ jobs:
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-    - name: Configure CMake
+    - name: Configure CMake (Linux)
+      if: runner.os == 'Linux'
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
@@ -62,6 +69,18 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -S ${{ github.workspace }}
+
+    - name: Configure CMake (Windows)
+      if: runner.os == 'Windows'
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_INSTALLATION_ROOT }}/scripts/buildsystems/vcpkg.cmake
+        -DVCPKG_TARGET_TRIPLET=x64-windows-static
+        -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>
         -S ${{ github.workspace }}
 
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.16)
+project(Lex C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+file(GLOB SOURCES "src/*.c")
+
+add_executable(te ${SOURCES})
+
+find_package(OpenGL REQUIRED)
+find_package(GLEW REQUIRED)
+find_package(SDL2 REQUIRED)
+
+# SDL2 target name varies between platforms and versions
+if(TARGET SDL2::SDL2-static)
+    target_link_libraries(te PRIVATE SDL2::SDL2-static)
+elseif(TARGET SDL2::SDL2)
+    target_link_libraries(te PRIVATE SDL2::SDL2)
+else()
+    target_include_directories(te PRIVATE ${SDL2_INCLUDE_DIRS})
+    target_link_libraries(te PRIVATE ${SDL2_LIBRARIES})
+endif()
+
+target_link_libraries(te PRIVATE OpenGL::GL GLEW::GLEW)
+
+if(WIN32)
+    # Required when linking against the static GLEW library on Windows
+    target_compile_definitions(te PRIVATE GLEW_STATIC)
+    target_link_libraries(te PRIVATE gdi32)
+else()
+    target_link_libraries(te PRIVATE m)
+endif()

--- a/src/file.c
+++ b/src/file.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <math.h>
 #include <string.h>
+#include <errno.h>
 #include "file.h"
 
 char *slurp_file_into_malloced_cstr(const char *file_path)

--- a/src/gl_extra.c
+++ b/src/gl_extra.c
@@ -7,9 +7,7 @@
 #include <errno.h>
 #include <math.h>
 
-#define GLFW_INCLUDE_GLEXT
 #include <GL/glew.h>
-#include <GLFW/glfw3.h>
 
 #include "file.h"
 #include "gl_extra.h"

--- a/src/gl_extra.h
+++ b/src/gl_extra.h
@@ -1,9 +1,7 @@
-#define GLFW_INCLUDE_GLEXT
-#include <GL/glew.h>
-#include <GLFW/glfw3.h>
-
 #ifndef GL_EXTRA_H_
 #define GL_EXTRA_H_
+
+#include <GL/glew.h>
 
 bool compile_shader_source(const GLchar *source, GLenum shader_type, GLuint *shader);
 bool compile_shader_file(const char *file_path, GLenum shader_type, GLuint *shader);


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate building and testing the project with CMake across multiple platforms and compiler configurations. The workflow ensures that code changes are validated on both Windows and Linux environments using different compilers, improving cross-platform reliability.

**CI/CD workflow enhancements:**

* Added `.github/workflows/cmake-multi-platform.yml` to build and test the project using CMake on both Windows and Linux with GCC, Clang, and MSVC compilers. This includes a matrix strategy for different OS/compiler combinations, automated configuration, build, and test steps for each combination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated multi-platform CI to run builds and tests across Windows and Linux for greater reliability.
  * Introduced a CMake-based cross-platform build configuration to simplify building the project on multiple systems.

* **Bug Fixes**
  * Fixed file I/O error handling so failures report and preserve system error information correctly.

* **Refactor**
  * Cleaned up graphics/header dependencies to reduce reliance on a specific windowing header and streamline compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->